### PR TITLE
fix: properly serve Univer's nested modules in browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,12 @@ docker compose up --build
 ```
 
 Then open <http://localhost:8000> to view the sheet.
+
+## Development
+
+Install the JavaScript dependencies so the import map in `templates/index.html` can resolve modules:
+
+```bash
+npm install
+python app.py
+```

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,6 +4,21 @@
     <meta charset="UTF-8">
     <title>Univer Sheets Demo</title>
     <link rel="stylesheet" href="/node_modules/@univerjs/sheets-ui/lib/index.css" />
+    <script type="importmap">
+        {
+            "imports": {
+                "@univerjs/core": "/node_modules/@univerjs/core/lib/index.js",
+                "@univerjs/engine-render": "/node_modules/@univerjs/engine-render/lib/index.js",
+                "@univerjs/ui": "/node_modules/@univerjs/ui/lib/index.js",
+                "@univerjs/sheets": "/node_modules/@univerjs/sheets/lib/index.js",
+                "@univerjs/sheets-ui": "/node_modules/@univerjs/sheets-ui/lib/index.js",
+                "@univerjs/themes": "/node_modules/@univerjs/themes/lib/index.js",
+                "@wendellhu/redi": "/node_modules/@wendellhu/redi/dist/esm/index.js",
+                "rxjs": "/node_modules/rxjs/dist/esm/index.js",
+                "rxjs/operators": "/node_modules/rxjs/dist/esm/operators/index.js"
+            }
+        }
+    </script>
     <style>
         html, body, #univer-container {
             height: 100%;
@@ -14,11 +29,11 @@
 <body>
     <div id="univer-container"></div>
     <script type="module">
-        import { Univer, UniverInstanceType } from '/node_modules/@univerjs/core/lib/index.js';
-        import { UniverRenderEnginePlugin } from '/node_modules/@univerjs/engine-render/lib/index.js';
-        import { UniverUIPlugin } from '/node_modules/@univerjs/ui/lib/index.js';
-        import { UniverSheetsPlugin } from '/node_modules/@univerjs/sheets/lib/index.js';
-        import { UniverSheetsUIPlugin } from '/node_modules/@univerjs/sheets-ui/lib/index.js';
+        import { Univer, UniverInstanceType } from '@univerjs/core';
+        import { UniverRenderEnginePlugin } from '@univerjs/engine-render';
+        import { UniverUIPlugin } from '@univerjs/ui';
+        import { UniverSheetsPlugin } from '@univerjs/sheets';
+        import { UniverSheetsUIPlugin } from '@univerjs/sheets-ui';
 
         const univer = new Univer({ locale: 'en' });
         univer.installPlugin(new UniverRenderEnginePlugin());


### PR DESCRIPTION
## Summary
- add import map so Univer browser modules resolve nested dependencies
- document installing Node packages for local development

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8da44545c83318a2277d108710590